### PR TITLE
1.0.1-b7

### DIFF
--- a/chris1278/extonoff/acp/main_module.php
+++ b/chris1278/extonoff/acp/main_module.php
@@ -28,8 +28,8 @@ class main_module
 
 		$this->page_title = $language->lang('EXTONOFF_TITLE');
 
-		$acp_controller->acp_module();
-
 		$acp_controller->set_page_url($this->u_action);
+
+		$acp_controller->acp_module();
 	}
 }

--- a/chris1278/extonoff/adm/style/acp_extonoff_confirm.html
+++ b/chris1278/extonoff/adm/style/acp_extonoff_confirm.html
@@ -1,0 +1,20 @@
+{% INCLUDE 'overall_header.html' %}
+
+<h1>{{ lang('EXTONOFF_TITLE') }}</h1>
+<p>{{ lang('EXTONOFF_EXPLAIN_1') }}</p>
+
+<form id="confirm" method="post" action="{{ S_CONFIRM_ACTION }}">
+	<fieldset>
+		<h1>{MESSAGE_TITLE}</h1>
+		<p>{MESSAGE_TEXT}</p>
+
+		{S_HIDDEN_FIELDS}
+
+		<div style="text-align: center;">
+			<input type="submit" name="confirm" value="{{ lang('YES') }}" class="button1">&nbsp; 
+			<input type="submit" name="cancel" value="{{ lang('NO') }}" class="button2">
+		</div>
+	</fieldset>
+</form>
+
+{% INCLUDE 'overall_footer.html' %}

--- a/chris1278/extonoff/adm/style/acp_extonoff_main.html
+++ b/chris1278/extonoff/adm/style/acp_extonoff_main.html
@@ -1,20 +1,13 @@
 {% INCLUDE 'overall_header.html' %}
 
 <h1>{{ lang('EXTONOFF_TITLE') }}</h1>
-<p>{{ lang('EXTONOFF_EXPLAIN') }}</p>
+<p>{{ lang('EXTONOFF_EXPLAIN_1') }}</p>
+<p>{{ lang('EXTONOFF_EXPLAIN_2') }}</p>
+<p>{{ lang('EXTONOFF_EXPLAIN_3') }}</p>
 
 <form method="post">
 	<fieldset>
 		<legend>{{ lang('EXTONOFF_ACTIVATE_OPTION') }}</legend>
-		<dl>
-			<dt>
-				<label>{{ lang('EXTONOFF_ACTIVATE') ~ lang('COLON') }}</label><br>
-				<span>{{ lang('EXTONOFF_ACTIVATE_EXPLAIN') }}</span>
-			</dt>
-			<dd>
-				<label><input class="button1" type="submit" name="extonoff_enable_all" value="{{ lang('EXTONOFF_ALL_ENABLE') }}"></label>
-			</dd>
-		</dl>
 		<dl>
 			<dt>
 				<label>{{ lang('EXTONOFF_DEACTIVATE') ~ lang('COLON') }}</label><br>
@@ -22,6 +15,15 @@
 			</dt>
 			<dd>
 				<label><input class="button1" type="submit" name="extonoff_disable_all" value="{{ lang('EXTONOFF_ALL_DISABLE') }}"></label>
+			</dd>
+		</dl>
+		<dl>
+			<dt>
+				<label>{{ lang('EXTONOFF_ACTIVATE') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('EXTONOFF_ACTIVATE_EXPLAIN') }}</span>
+			</dt>
+			<dd>
+				<label><input class="button1" type="submit" name="extonoff_enable_all" value="{{ lang('EXTONOFF_ALL_ENABLE') }}"></label>
 			</dd>
 		</dl>
 	</fieldset>
@@ -33,30 +35,39 @@
 		
 <form id="extonoff_settings" method="post" >
 	<fieldset>
-		<legend>{{ lang('EXTONOFF_EXTRA_BUTTONS') }}</legend>
+		<legend>{{ lang('EXTONOFF_SETTINGS_TITLE') }}</legend>
 		<dl>
 			<dt>
-				<label>{{ lang('EXTONOFF_ENABLE_BUTTONS') ~ lang('COLON') }}</label><br>
-				<span>{{ lang('EXTONOFF_ENABLE_BUTTONS_EXPLAIN') }}</span>
+				<label>{{ lang('EXTONOFF_INTEGRATION') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('EXTONOFF_INTEGRATION_EXPLAIN') }}</span>
 			</dt>
 			<dd>
-				<label><input type="radio" class="radio" name="extonoff_enable_buttons" value="1" {{ EXTONOFF_ENABLE_BUTTONS == 1 ? 'checked="checked"' }}> {{ lang('YES') }}</label>
-				<label><input type="radio" class="radio" name="extonoff_enable_buttons" value="0" {{ EXTONOFF_ENABLE_BUTTONS == 0 ? 'checked="checked"' }}> {{ lang('NO') }}</label>
+				<label><input type="radio" class="radio" name="extonoff_enable_integration" value="1" {{ EXTONOFF_ENABLE_INTEGRATION == 1 ? 'checked="checked"' }}> {{ lang('YES') }}</label>
+				<label><input type="radio" class="radio" name="extonoff_enable_integration" value="0" {{ EXTONOFF_ENABLE_INTEGRATION == 0 ? 'checked="checked"' }}> {{ lang('NO') }}</label>
 				{{ _self.extonoff_default(lang('NO')) }}
 			</dd>
 		</dl>
-	</fieldset>
 	
-	<fieldset>
-		<legend>{{ lang('EXTONOFF_ADMIN_LOG') }}</legend>
 		<dl>
 			<dt>
-				<label>{{ lang('EXTONOFF_ENABLE_LOG') ~ lang('COLON') }}</label><br>
-				<span>{{ lang('EXTONOFF_ENABLE_LOG_EXPLAIN') }}</span>
+				<label>{{ lang('EXTONOFF_LOG') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('EXTONOFF_LOG_EXPLAIN') }}</span>
 			</dt>
 			<dd>
 				<label><input type="radio" class="radio" name="extonoff_enable_log" value="1" {{ EXTONOFF_ENABLE_LOG == 1 ? 'checked="checked"' }}> {{ lang('YES') }}</label>
 				<label><input type="radio" class="radio" name="extonoff_enable_log" value="0" {{ EXTONOFF_ENABLE_LOG == 0 ? 'checked="checked"' }}> {{ lang('NO') }}</label>
+				{{ _self.extonoff_default(lang('YES')) }}
+			</dd>
+		</dl>
+	
+		<dl>
+			<dt>
+				<label>{{ lang('EXTONOFF_CONFIRMATION') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('EXTONOFF_CONFIRMATION_EXPLAIN') }}</span>
+			</dt>
+			<dd>
+				<label><input type="radio" class="radio" name="extonoff_enable_confirmation" value="1" {{ EXTONOFF_ENABLE_CONFIRMATION == 1 ? 'checked="checked"' }}> {{ lang('YES') }}</label>
+				<label><input type="radio" class="radio" name="extonoff_enable_confirmation" value="0" {{ EXTONOFF_ENABLE_CONFIRMATION == 0 ? 'checked="checked"' }}> {{ lang('NO') }}</label>
 				{{ _self.extonoff_default(lang('YES')) }}
 			</dd>
 		</dl>
@@ -76,6 +87,6 @@
 
 {% macro extonoff_default(value) %}
 	<div class="extonoff_default">
-		<strong>{{ lang('EXTONOFF_DEFAULT') ~ lang('COLON') }}</strong> {{ value }}
+		{{ lang('EXTONOFF_DEFAULT') ~ lang('COLON') }} {{ value }}
 	</div>
 {% endmacro %}

--- a/chris1278/extonoff/adm/style/event/acp_ext_list_disabled_title_after.html
+++ b/chris1278/extonoff/adm/style/event/acp_ext_list_disabled_title_after.html
@@ -1,5 +1,6 @@
-{% if EXTONOFF_LISTENER_BUTTONS %}
+{% if EXTONOFF_INTEGRATION %}
 	{% INCLUDECSS 'css/acp_extonoff_buttons.css' %}
+	<strong>( {{ lang('EXTONOFF_INSTALLED') ~ lang('COLON') ~ ' ' ~ EXTONOFF_INACTIVE_EXTS }} / {{ lang('EXTONOFF_NOT_INSTALLED') ~ lang('COLON') ~ ' ' ~ EXTONOFF_NOT_INSTALLED_EXTS }} )</strong>
 	<form id="extonoff_button_enable" method="post">
 		<input class="button1" type="submit" name="extonoff_enable_all" value="{{ lang('EXTONOFF_ALL_ENABLE') }}">
 	</form>

--- a/chris1278/extonoff/adm/style/event/acp_ext_list_enabled_title_after.html
+++ b/chris1278/extonoff/adm/style/event/acp_ext_list_enabled_title_after.html
@@ -1,5 +1,6 @@
-{% if EXTONOFF_LISTENER_BUTTONS %}
+{% if EXTONOFF_INTEGRATION %}
 	{% INCLUDECSS 'css/acp_extonoff_buttons.css' %}
+	<strong>( {{ EXTONOFF_ACTIVE_EXTS }} )</strong>
 	<form id="extonoff_button_disable" method="post">
 		<input class="button1" type="submit" name="extonoff_disable_all" value="{{ lang('EXTONOFF_ALL_DISABLE') }}">
 	</form>

--- a/chris1278/extonoff/composer.json
+++ b/chris1278/extonoff/composer.json
@@ -3,7 +3,7 @@
 	"type": "phpbb-extension",
 	"description": "With this extension it is possible to deactivate or activate all active extensions at once.",
 	"homepage": "https://www.phpbb.de/community/viewtopic.php?f=149&t=242009",
-	"version": "1.0.1-b6",
+	"version": "1.0.1-b7",
 	"time": "2022-04-23",
 	"license": "GPL-2.0-only",
 	"authors": [

--- a/chris1278/extonoff/event/acp_listener.php
+++ b/chris1278/extonoff/event/acp_listener.php
@@ -25,13 +25,13 @@ class acp_listener implements EventSubscriberInterface
 	{
 		return [
 			'core.common'							=> 'todo',
-			'core.acp_extensions_run_action_before'	=> 'enable_disable',
+			'core.acp_extensions_run_action_before'	=> 'ext_manager',
 		];
 	}
 
-	public function enable_disable()
+	public function ext_manager($event)
 	{
-		$this->extonoff->enable_disable();
+		$this->extonoff->ext_manager($event);
 	}
 
 	public function todo()

--- a/chris1278/extonoff/language/de/acp_extonoff.php
+++ b/chris1278/extonoff/language/de/acp_extonoff.php
@@ -37,26 +37,44 @@ if (empty($lang) || !is_array($lang))
 // ’ « » “ ” … „ “
 
 $lang = array_merge($lang, [
-	'EXTONOFF_EXPLAIN'						=> 'Hier hast du die Möglichkeit alle Erweiterungen auf einmal zu deaktivieren bzw. zu aktivieren.<br><br>Zusätzlich hast du die Möglichkeit dir auch entsprechend die Buttons direkt in der Ansicht <strong>„Erweiterungen verwalten“</strong> anzeigen zu lassen und diese dort zu nutzen.<br><br><strong style="color: red">Achtung:</strong>  Es lassen sich nur installierte Erweiterungen aktivieren bzw. deaktivieren. Erweiterungen die zwar in der Liste aufgeführt, aber noch nicht installiert sind, werden dabei nicht berücksichtigt.',
+	// settings head
+	'EXTONOFF_EXPLAIN_1'					=> 'Hier hast du die Möglichkeit alle Erweiterungen auf einmal zu deaktivieren bzw. zu aktivieren.',
+	'EXTONOFF_EXPLAIN_2'					=> 'Zusätzlich hast du die Möglichkeit dir auch entsprechend die Buttons direkt in der Ansicht „Erweiterungen verwalten“ anzeigen zu lassen.',
+	'EXTONOFF_EXPLAIN_3'					=> '<strong style="color: red">Achtung:</strong>  Es lassen sich nur installierte Erweiterungen aktivieren bzw. deaktivieren. Erweiterungen die zwar in der Liste aufgeführt, aber noch nicht installiert sind, werden dabei nicht berücksichtigt.',
+
+	// settings buttons
 	'EXTONOFF_ACTIVATE_OPTION'				=> 'Alle Erweiterungen aktivieren/deaktivieren',
-	'EXTONOFF_ACTIVATE'						=> 'Alle Erweiterungen aktivieren',
-	'EXTONOFF_ACTIVATE_EXPLAIN'				=> 'Durch drücken des Buttons <strong>„Alle Erweiterungen aktivieren“</strong> werden alle installierten aber deaktivierten Erweiterungen aktiviert.',
-	'EXTONOFF_ALL_ENABLE'					=> 'Alle Erweiterungen aktivieren',
-	'EXTONOFF_ACTIVATION_SUCCESFULL'		=> '%1$u von %2$u deaktivierten Erweiterungen wurden aktiviert.',
-	'EXTONOFF_ACTIVATION_UNNECESSARY'		=> 'Die Erweiterungen sind bereits alle aktiviert. Eine nochmalige Aktivierung ist nicht notwendig.',
 	'EXTONOFF_DEACTIVATE'					=> 'Alle Erweiterungen deaktivieren',
-	'EXTONOFF_DEACTIVATE_EXPLAIN'			=> 'Durch drücken des Buttons <strong>„Alle Erweiterungen deaktivieren“</strong> werden alle aktivierten Erweiterungen deaktiviert.<br><br><strong>Hinweis:</strong> Die Erweiterung <strong>„Enable/disable extensions completely“</strong> bleibt dabei aktiviert. Diese musst du dann manuell deaktivieren.',
+	'EXTONOFF_DEACTIVATE_EXPLAIN'			=> 'Durch drücken des Buttons „Alle Erweiterungen deaktivieren“ werden alle aktivierten Erweiterungen deaktiviert, mit Ausnahme der Erweiterung „Enable/disable extensions completely“. Diese musst du manuell deaktivieren.',
 	'EXTONOFF_ALL_DISABLE'					=> 'Alle Erweiterungen deaktivieren',
-	'EXTONOFF_DEACTIVATION_SUCCESFULL'		=> '%1$u von %2$u aktivierten Erweiterungen wurden deaktiviert.',
-	'EXTONOFF_DEACTIVATION_UNNECESSARY'		=> 'Die Erweiterungen sind bereits alle deaktiviert. Eine nochmalige Deaktivierung ist nicht notwendig.',
+	'EXTONOFF_ACTIVATE'						=> 'Alle Erweiterungen aktivieren',
+	'EXTONOFF_ACTIVATE_EXPLAIN'				=> 'Durch drücken des Buttons „Alle Erweiterungen aktivieren“ werden alle installierten aber deaktivierten Erweiterungen aktiviert.',
+	'EXTONOFF_ALL_ENABLE'					=> 'Alle Erweiterungen aktivieren',
+
+	// settings info
 	'EXTONOFF_DEACTIVATION_INFO'			=> 'Es können von insgesamt <strong>%2$u</strong> aktiven Erweiterungen <strong>%1$u</strong> Erweiterungen mittels dieser Erweiterung deaktiviert werden.',
-	'EXTONOFF_EXTRA_BUTTONS'				=> 'Zusatz Buttons in der Ansicht „Erweiterungen verwalten“',
-	'EXTONOFF_ENABLE_BUTTONS'				=> 'Zusatz-Buttons aktivieren',
-	'EXTONOFF_ENABLE_BUTTONS_EXPLAIN'		=> 'Wenn du diese Option aktivierst, werden in der Ansicht <strong>„Erweiterungen verwalten“</strong> ebenfalls Buttons eingeblendet, mit denen du auch dort alle Erweiterungen aktiveren bzw. deaktivieren kannst.',
-	'EXTONOFF_ADMIN_LOG'					=> 'Log-Eintrag',
-	'EXTONOFF_ENABLE_LOG'					=> 'Log-Eintrag aktivieren',
-	'EXTONOFF_ENABLE_LOG_EXPLAIN'			=> 'Hier kannst du festlegen, ob bei den Aktionen <strong>„Alle Erweiterungen aktivieren“</strong> und <strong>„Alle Erweiterungen deaktivieren“</strong> ein Eintrag im Administrator-Log hinzugefügt werden soll.',
+
+	// settings
+	'EXTONOFF_SETTINGS_TITLE'				=> 'Einstellungen',
+	'EXTONOFF_INTEGRATION'					=> 'Integration in „Erweiterungen verwalten“',
+	'EXTONOFF_INTEGRATION_EXPLAIN'			=> 'Wenn du diese Option aktivierst, werden in der Ansicht „Erweiterungen verwalten“ ebenfalls Buttons eingeblendet, mit denen du auch dort alle Erweiterungen aktiveren bzw. deaktivieren kannst. Ausserdem wird die Anzahl der aktivierten, deaktivierten und nicht installierten Erweiterungen angezeigt.',
+	'EXTONOFF_LOG'							=> 'Log-Eintrag',
+	'EXTONOFF_LOG_EXPLAIN'					=> 'Hier kannst du festlegen, ob bei den Aktionen „Alle Erweiterungen aktivieren“ und „Alle Erweiterungen deaktivieren“ ein Eintrag im Administrator-Log hinzugefügt werden soll.',
+	'EXTONOFF_CONFIRMATION'					=> 'Rückfrage',
+	'EXTONOFF_CONFIRMATION_EXPLAIN'			=> 'Hier kannst du festlegen, ob bei den Aktionen „Alle Erweiterungen aktivieren“ und „Alle Erweiterungen deaktivieren“ eine Rückfrage erfolgen soll, die bestätigt werden muss.',
+
+	// misc
 	'EXTONOFF_DEFAULT'						=> 'Standard',
+	'EXTONOFF_INSTALLED'					=> 'installiert',
+	'EXTONOFF_NOT_INSTALLED'				=> 'nicht installiert',
+
+	// messages
 	'EXTONOFF_MSG_ACTIVATION_ABORTED'		=> 'Der Vorgang „Alle Erweiterungen aktivieren“ wurde unterbrochen, da die folgende Erweiterung nicht aktiviert werden konnte:',
 	'EXTONOFF_MSG_SETTINGS_SAVED'			=> 'Einstellungen erfolgreich gespeichert.',
+	'EXTONOFF_MSG_CONFIRM_DISABLE'			=> 'Bist du dir sicher, dass du %1$u Erweiterungen deaktivieren möchtest?',
+	'EXTONOFF_MSG_CONFIRM_ENABLE'			=> 'Bist du dir sicher, dass du %1$u Erweiterungen aktivieren möchtest?',
+	'EXTONOFF_MSG_DEACTIVATION_SUCCESFULL'	=> '%1$u von %2$u aktivierten Erweiterungen wurden deaktiviert.',
+	'EXTONOFF_MSG_DEACTIVATION_UNNECESSARY'	=> 'Die Erweiterungen sind bereits alle deaktiviert. Eine nochmalige Deaktivierung ist nicht notwendig.',
+	'EXTONOFF_MSG_ACTIVATION_SUCCESFULL'	=> '%1$u von %2$u deaktivierten Erweiterungen wurden aktiviert.',
+	'EXTONOFF_MSG_ACTIVATION_UNNECESSARY'	=> 'Die Erweiterungen sind bereits alle aktiviert. Eine nochmalige Aktivierung ist nicht notwendig.',
 ]);

--- a/chris1278/extonoff/language/de_x_sie/acp_extonoff.php
+++ b/chris1278/extonoff/language/de_x_sie/acp_extonoff.php
@@ -37,26 +37,44 @@ if (empty($lang) || !is_array($lang))
 // ’ « » “ ” … „ “
 
 $lang = array_merge($lang, [
-	'EXTONOFF_EXPLAIN'						=> 'Hier haben Sie die Möglichkeit alle Erweiterungen auf einmal zu deaktivieren bzw. zu aktivieren.<br><br>Zusätzlich haben Sie die Möglichkeit auch entsprechend die Buttons direkt in der Ansicht <strong>„Erweiterungen verwalten“</strong> anzeigen zu lassen und diese dort zu nutzen.<br><br><strong style="color: red">Achtung:</strong>  Es lassen sich nur installierte Erweiterungen aktivieren bzw. deaktivieren. Erweiterungen die zwar in der Liste aufgeführt, aber noch nicht installiert sind, werden dabei nicht berücksichtigt.',
+	// settings head
+	'EXTONOFF_EXPLAIN_1'					=> 'Hier haben Sie die Möglichkeit alle Erweiterungen auf einmal zu deaktivieren bzw. zu aktivieren.',
+	'EXTONOFF_EXPLAIN_2'					=> 'Zusätzlich haben Sie die Möglichkeit auch entsprechend die Buttons direkt in der Ansicht „Erweiterungen verwalten“ anzeigen zu lassen.',
+	'EXTONOFF_EXPLAIN_3'					=> '<strong style="color: red">Achtung:</strong> Es lassen sich nur installierte Erweiterungen aktivieren bzw. deaktivieren. Erweiterungen die zwar in der Liste aufgeführt, aber noch nicht installiert sind, werden dabei nicht berücksichtigt.',
+
+	// settings buttons
 	'EXTONOFF_ACTIVATE_OPTION'				=> 'Alle Erweiterungen aktivieren/deaktivieren',
-	'EXTONOFF_ACTIVATE'						=> 'Alle Erweiterungen aktivieren',
-	'EXTONOFF_ACTIVATE_EXPLAIN'				=> 'Durch drücken des Buttons <strong>„Alle Erweiterungen aktivieren“</strong> werden alle installierten aber deaktivierten Erweiterungen aktiviert.',
-	'EXTONOFF_ALL_ENABLE'					=> 'Alle Erweiterungen aktivieren',
-	'EXTONOFF_ACTIVATION_SUCCESFULL'		=> '%1$u von %2$u deaktivierten Erweiterungen wurden aktiviert.',
-	'EXTONOFF_ACTIVATION_UNNECESSARY'		=> 'Die Erweiterungen sind bereits alle aktiviert. Eine nochmalige Aktivierung ist nicht notwendig.',
 	'EXTONOFF_DEACTIVATE'					=> 'Alle Erweiterungen deaktivieren',
-	'EXTONOFF_DEACTIVATE_EXPLAIN'			=> 'Durch drücken des Buttons <strong>„Alle Erweiterungen deaktivieren“</strong> werden alle aktivierten Erweiterungen deaktiviert.<br><br><strong>Hinweis:</strong> Die Erweiterung <strong>„Enable/disable extensions completely“</strong> bleibt dabei aktiviert. Diese müssen Sie dann manuell deaktivieren.',
+	'EXTONOFF_DEACTIVATE_EXPLAIN'			=> 'Durch drücken des Buttons „Alle Erweiterungen deaktivieren“ werden alle aktivierten Erweiterungen deaktiviert, mit Ausnahme der Erweiterung „Enable/disable extensions completely“. Diese müssen Sie manuell deaktivieren.',
 	'EXTONOFF_ALL_DISABLE'					=> 'Alle Erweiterungen deaktivieren',
-	'EXTONOFF_DEACTIVATION_SUCCESFULL'		=> '%1$u von %2$u aktivierten Erweiterungen wurden deaktiviert.',
-	'EXTONOFF_DEACTIVATION_UNNECESSARY'		=> 'Die Erweiterungen sind bereits alle deaktiviert. Eine nochmalige Deaktivierung ist nicht notwendig.',
+	'EXTONOFF_ACTIVATE'						=> 'Alle Erweiterungen aktivieren',
+	'EXTONOFF_ACTIVATE_EXPLAIN'				=> 'Durch drücken des Buttons „Alle Erweiterungen aktivieren“ werden alle installierten aber deaktivierten Erweiterungen aktiviert.',
+	'EXTONOFF_ALL_ENABLE'					=> 'Alle Erweiterungen aktivieren',
+
+	// settings info
 	'EXTONOFF_DEACTIVATION_INFO'			=> 'Es können von insgesamt <strong>%2$u</strong> aktiven Erweiterungen <strong>%1$u</strong> Erweiterungen mittels dieser Erweiterung deaktiviert werden.',
-	'EXTONOFF_EXTRA_BUTTONS'				=> 'Zusatz Buttons in der Ansicht „Erweiterungen verwalten“',
-	'EXTONOFF_ENABLE_BUTTONS'				=> 'Zusatz-Buttons aktivieren',
-	'EXTONOFF_ENABLE_BUTTONS_EXPLAIN'		=> 'Wenn Sie diese Option aktivieren, werden in der Ansicht <strong>„Erweiterungen verwalten“</strong> ebenfalls Buttons eingeblendet, mit denen Sie auch dort alle Erweiterungen aktiveren bzw. deaktivieren können.',
-	'EXTONOFF_ADMIN_LOG'					=> 'Log-Eintrag',
-	'EXTONOFF_ENABLE_LOG'					=> 'Log-Eintrag aktivieren',
-	'EXTONOFF_ENABLE_LOG_EXPLAIN'			=> 'Hier können Sie festlegen, ob bei den Aktionen <strong>„Alle Erweiterungen aktivieren“</strong> und <strong>„Alle Erweiterungen deaktivieren“</strong> ein Eintrag im Administrator-Log hinzugefügt werden soll.',
+
+	// settings
+	'EXTONOFF_SETTINGS_TITLE'				=> 'Einstellungen',
+	'EXTONOFF_INTEGRATION'					=> 'Integration in „Erweiterungen verwalten“',
+	'EXTONOFF_INTEGRATION_EXPLAIN'			=> 'Wenn Sie diese Option aktivieren, werden in der Ansicht „Erweiterungen verwalten“ ebenfalls Buttons eingeblendet, mit denen Sie auch dort alle Erweiterungen aktiveren bzw. deaktivieren können. Ausserdem wird die Anzahl der aktivierten, deaktivierten und nicht installierten Erweiterungen angezeigt.',
+	'EXTONOFF_LOG'							=> 'Log-Eintrag',
+	'EXTONOFF_LOG_EXPLAIN'					=> 'Hier können Sie festlegen, ob bei den Aktionen „Alle Erweiterungen aktivieren“ und „Alle Erweiterungen deaktivieren“ ein Eintrag im Administrator-Log hinzugefügt werden soll.',
+	'EXTONOFF_CONFIRMATION'					=> 'Rückfrage',
+	'EXTONOFF_CONFIRMATION_EXPLAIN'			=> 'Hier können Sie festlegen, ob bei den Aktionen „Alle Erweiterungen aktivieren“ und „Alle Erweiterungen deaktivieren“ eine Rückfrage erfolgen soll, die bestätigt werden muss.',
+
+	// misc
 	'EXTONOFF_DEFAULT'						=> 'Standard',
+	'EXTONOFF_INSTALLED'					=> 'installiert',
+	'EXTONOFF_NOT_INSTALLED'				=> 'nicht installiert',
+
+	// messages
 	'EXTONOFF_MSG_ACTIVATION_ABORTED'		=> 'Der Vorgang „Alle Erweiterungen aktivieren“ wurde unterbrochen, da die folgende Erweiterung nicht aktiviert werden konnte:',
 	'EXTONOFF_MSG_SETTINGS_SAVED'			=> 'Einstellungen erfolgreich gespeichert.',
+	'EXTONOFF_MSG_CONFIRM_DISABLE'			=> 'Sind Sie sich sicher, dass Sie %1$u Erweiterungen deaktivieren möchten?',
+	'EXTONOFF_MSG_CONFIRM_ENABLE'			=> 'Sind Sie sich sicher, dass Sie %1$u Erweiterungen aktivieren möchten?',
+	'EXTONOFF_MSG_DEACTIVATION_SUCCESFULL'	=> '%1$u von %2$u aktivierten Erweiterungen wurden deaktiviert.',
+	'EXTONOFF_MSG_DEACTIVATION_UNNECESSARY'	=> 'Die Erweiterungen sind bereits alle deaktiviert. Eine nochmalige Deaktivierung ist nicht notwendig.',
+	'EXTONOFF_MSG_ACTIVATION_SUCCESFULL'	=> '%1$u von %2$u deaktivierten Erweiterungen wurden aktiviert.',
+	'EXTONOFF_MSG_ACTIVATION_UNNECESSARY'	=> 'Die Erweiterungen sind bereits alle aktiviert. Eine nochmalige Aktivierung ist nicht notwendig.',
 ]);

--- a/chris1278/extonoff/language/en/acp_extonoff.php
+++ b/chris1278/extonoff/language/en/acp_extonoff.php
@@ -37,26 +37,44 @@ if (empty($lang) || !is_array($lang))
 // ’ « » “ ” … „ “
 
 $lang = array_merge($lang, [
-	'EXTONOFF_EXPLAIN'						=> 'Here you have the option of deactivating or activating all extensions at once.<br><br>Here you can either activate all or deactivate all extensions that are activated using the buttons.<br><br>You also have the option of displaying the buttons directly in the <strong>"Manage Extensions"</strong> view and using them there.<br><br><strong style="color: red">Warning:</strong> Only the extensions that are installed can be activated or deactivated. Extensions that are in the list but are not yet installed are not taken into account.',
+	// settings head
+	'EXTONOFF_EXPLAIN_1'					=> 'Here you have the option of deactivating or activating all extensions at once.',
+	'EXTONOFF_EXPLAIN_2'					=> 'You also have the option of displaying the buttons directly in the "Manage Extensions" view.',
+	'EXTONOFF_EXPLAIN_3'					=> '<strong style="color: red">Warning:</strong> Only the extensions that are installed can be activated or deactivated. Extensions that are in the list but are not yet installed are not taken into account.',
+
+	// settings buttons
 	'EXTONOFF_ACTIVATE_OPTION'				=> 'All Extensions enable/disable',
-	'EXTONOFF_ACTIVATE'						=> 'Activate all extensions',
-	'EXTONOFF_ACTIVATE_EXPLAIN'				=> 'By pressing the <strong>"Activate all extensions"</strong> button, all installed but deactivated extensions will be activated.',
-	'EXTONOFF_ALL_ENABLE'					=> 'Activate all extensions',
-	'EXTONOFF_ACTIVATION_SUCCESFULL'		=> '%1$u of %2$u disabled extensions have been enabled.',
-	'EXTONOFF_ACTIVATION_UNNECESSARY'		=> 'The extensions are already activated. A renewed activation is not necessary.',
 	'EXTONOFF_DEACTIVATE'					=> 'Disable all extensions',
-	'EXTONOFF_DEACTIVATE_EXPLAIN'			=> 'By pressing the button <strong>"Disable all extensions"</strong>, all activated extensions will be deactivated.<br><br><strong>Note:</strong> The extension <strong>"Enable /disable extensions completely"</strong> remains activated. You then have to deactivate them manually.',
+	'EXTONOFF_DEACTIVATE_EXPLAIN'			=> 'By pressing the button "Disable all extensions", all activated extensions will be deactivated execept for the extension "Enable /disable extensions completely". You have to deactivate them manually.',
 	'EXTONOFF_ALL_DISABLE'					=> 'Disable all extensions',
-	'EXTONOFF_DEACTIVATION_SUCCESFULL'		=> '%1$u of %2$u enabled extensions have been disabled.',
-	'EXTONOFF_DEACTIVATION_UNNECESSARY'		=> 'The extensions are already disabled. A repeated deactivation is not necessary.',
+	'EXTONOFF_ACTIVATE'						=> 'Activate all extensions',
+	'EXTONOFF_ACTIVATE_EXPLAIN'				=> 'By pressing the "Activate all extensions" button, all installed but deactivated extensions will be activated.',
+	'EXTONOFF_ALL_ENABLE'					=> 'Activate all extensions',
+
+	// settings info
 	'EXTONOFF_DEACTIVATION_INFO'			=> 'Out of a total of <strong>%2$u</strong> active extensions, <strong>%1$u</strong> extensions can be deactivated using this extension.',
-	'EXTONOFF_EXTRA_BUTTONS'				=> 'Additional buttons in the "Manage extensions" view',
-	'EXTONOFF_ENABLE_BUTTONS'				=> 'Activate additional buttons',
-	'EXTONOFF_ENABLE_BUTTONS_EXPLAIN'		=> 'If you activate this option, buttons are also displayed in the <strong>"Manage extensions"</strong> view with which you can activate or deactivate all extensions there.',
-	'EXTONOFF_ADMIN_LOG'					=> 'Log entry',
-	'EXTONOFF_ENABLE_LOG'					=> 'Activate log entry',
-	'EXTONOFF_ENABLE_LOG_EXPLAIN'			=> 'Here you can specify whether an entry should be added to the administrator log for the actions <strong>"Activate all extensions"</strong> and <strong>"Deactivate all extensions"</strong>.',
+
+	// settings
+	'EXTONOFF_SETTINGS_TITLE'				=> 'Settings',
+	'EXTONOFF_INTEGRATION'					=> 'Activate additional buttons',
+	'EXTONOFF_INTEGRATION_EXPLAIN'			=> 'If you activate this option, buttons are also displayed in the "Manage extensions" view with which you can activate or deactivate all extensions there. In addition, the number of activated, deactivated and not installed extensions is displayed.',
+	'EXTONOFF_LOG'							=> 'Log entry',
+	'EXTONOFF_LOG_EXPLAIN'					=> 'Here you can specify whether an entry should be added to the administrator log for the actions "Activate all extensions" and "Deactivate all extensions".',
+	'EXTONOFF_CONFIRMATION'					=> 'Confirmation',
+	'EXTONOFF_CONFIRMATION_EXPLAIN'			=> 'Here you can specify whether the actions "Activate all extensions" and "Deactivate all extensions" should be prompted and must be confirmed.',
+
+	// misc
 	'EXTONOFF_DEFAULT'						=> 'Default',
+	'EXTONOFF_INSTALLED'					=> 'installed',
+	'EXTONOFF_NOT_INSTALLED'				=> 'not installed',
+
+	// messages
 	'EXTONOFF_MSG_ACTIVATION_ABORTED'		=> 'The "Activate all extensions" operation was interrupted because the following extension could not be activated:',
 	'EXTONOFF_MSG_SETTINGS_SAVED'			=> 'Settings saved successfully.',
+	'EXTONOFF_MSG_CONFIRM_DISABLE'			=> 'Are you sure that you wish to disable %u extensions?',
+	'EXTONOFF_MSG_CONFIRM_ENABLE'			=> 'Are you sure that you wish to enable %u extensions?',
+	'EXTONOFF_MSG_DEACTIVATION_SUCCESFULL'	=> '%1$u of %2$u enabled extensions have been disabled.',
+	'EXTONOFF_MSG_DEACTIVATION_UNNECESSARY'	=> 'The extensions are already disabled. A repeated deactivation is not necessary.',
+	'EXTONOFF_MSG_ACTIVATION_SUCCESFULL'	=> '%1$u of %2$u disabled extensions have been enabled.',
+	'EXTONOFF_MSG_ACTIVATION_UNNECESSARY'	=> 'The extensions are already activated. A renewed activation is not necessary.',
 ]);

--- a/chris1278/extonoff/migrations/v_1_0_1_database.php
+++ b/chris1278/extonoff/migrations/v_1_0_1_database.php
@@ -20,8 +20,9 @@ class v_1_0_1_database extends \phpbb\db\migration\migration
 	public function update_data()
 	{
 		return [
-			['config.add',		['extonoff_enable_buttons', 0]],
+			['config.add',		['extonoff_enable_integration', 0]],
 			['config.add',		['extonoff_enable_log', 1]],
+			['config.add',		['extonoff_enable_confirmation', 1]],
 			['config.add',		['extonoff_exec_todo', 0]],
 			['config.add',		['extonoff_todo_purge_cache', 0]],
 			['config_text.add', ['extonoff_todo_add_log', '']],


### PR DESCRIPTION
* Fix: `u_action` war im Controller nicht verfügbar.
* Es gibt jetzt eine Rückfrage bei Aktivierung/Deaktivierung, abschaltbar.
* Im ExtManager wird jetzt auch die Anzahl der aktivierten, deaktivierten und nicht-installierten Erweiterungen angezeigt.
* Für die Rückfrage neues Template `acp_extonoff_confirm.html` hinzugefügt.
* Im Controller die ExtManager Behandlung von Aktivierung/Deaktivierung separiert.
* Im ACP Modul einen neuen Schalter für die Rückfrage eingebaut.
* ACP Modul etwas überarbeitet und kompakter gestaltet.
* Neue Sprachvariablen hinzugefügt.
* Zahlreiche Änderungen in den Sprachdateien.