### PR TITLE
1.0.1-b8

### DIFF
--- a/chris1278/extonoff/adm/style/acp_extonoff_confirm.html
+++ b/chris1278/extonoff/adm/style/acp_extonoff_confirm.html
@@ -5,16 +5,18 @@
 
 <form id="confirm" method="post" action="{{ S_CONFIRM_ACTION }}">
 	<fieldset>
-		<h1>{MESSAGE_TITLE}</h1>
+		<h2>{MESSAGE_TITLE}</h1>
 		<p>{MESSAGE_TEXT}</p>
 
 		{S_HIDDEN_FIELDS}
 
-		<div style="text-align: center;">
+		<fieldset class="submit-buttons">
 			<input type="submit" name="confirm" value="{{ lang('YES') }}" class="button1">&nbsp; 
 			<input type="submit" name="cancel" value="{{ lang('NO') }}" class="button2">
-		</div>
+		</fieldset>
 	</fieldset>
 </form>
 
 {% INCLUDE 'overall_footer.html' %}
+
+{% INCLUDECSS '@chris1278_extonoff/css/acp_extonoff_extmgr.css' %}

--- a/chris1278/extonoff/adm/style/acp_extonoff_main.html
+++ b/chris1278/extonoff/adm/style/acp_extonoff_main.html
@@ -14,7 +14,7 @@
 				<span>{{ lang('EXTONOFF_DEACTIVATE_EXPLAIN') }}</span>
 			</dt>
 			<dd>
-				<label><input class="button1" type="submit" name="extonoff_disable_all" value="{{ lang('EXTONOFF_ALL_DISABLE') }}"></label>
+				<label><input class="button1" type="submit" name="extonoff_disable_all" value="{{ lang('EXTONOFF_ALL_DISABLE') }} ({{ EXTONOFF_ACTIVE_EXTS }})"{{ EXTONOFF_ACTIVE_EXTS == 0 ? ' disabled' }}></label>
 			</dd>
 		</dl>
 		<dl>
@@ -23,16 +23,12 @@
 				<span>{{ lang('EXTONOFF_ACTIVATE_EXPLAIN') }}</span>
 			</dt>
 			<dd>
-				<label><input class="button1" type="submit" name="extonoff_enable_all" value="{{ lang('EXTONOFF_ALL_ENABLE') }}"></label>
+				<label><input class="button1" type="submit" name="extonoff_enable_all" value="{{ lang('EXTONOFF_ALL_ENABLE') }} ({{ EXTONOFF_INACTIVE_EXTS }})"{{ EXTONOFF_INACTIVE_EXTS == 0 ? ' disabled' }}></label>
 			</dd>
 		</dl>
 	</fieldset>
 </form>
 	
-<div id="extonoff_infobox">
-	{{ EXTONOFF_DEACTIVATION_INFO }}
-</div>
-		
 <form id="extonoff_settings" method="post" >
 	<fieldset>
 		<legend>{{ lang('EXTONOFF_SETTINGS_TITLE') }}</legend>

--- a/chris1278/extonoff/adm/style/css/acp_extonoff.css
+++ b/chris1278/extonoff/adm/style/css/acp_extonoff.css
@@ -45,3 +45,7 @@ label input.button1 {
 	margin-top: 1em;
 	font-size: .9em;
 }
+
+input[type="submit"]:disabled {
+  color: silver;
+}

--- a/chris1278/extonoff/adm/style/css/acp_extonoff_extmgr.css
+++ b/chris1278/extonoff/adm/style/css/acp_extonoff_extmgr.css
@@ -11,3 +11,11 @@
 #extonoff_button_disable {
 	float: right;
 }
+
+#confirm h2 {
+	margin-bottom: .25em;
+}
+
+input[type="submit"]:disabled {
+  color: silver;
+}

--- a/chris1278/extonoff/adm/style/event/acp_ext_list_disabled_title_after.html
+++ b/chris1278/extonoff/adm/style/event/acp_ext_list_disabled_title_after.html
@@ -1,7 +1,7 @@
 {% if EXTONOFF_INTEGRATION %}
-	{% INCLUDECSS 'css/acp_extonoff_buttons.css' %}
+	{% INCLUDECSS 'css/acp_extonoff_extmgr.css' %}
 	<strong>( {{ lang('EXTONOFF_INSTALLED') ~ lang('COLON') ~ ' ' ~ EXTONOFF_INACTIVE_EXTS }} / {{ lang('EXTONOFF_NOT_INSTALLED') ~ lang('COLON') ~ ' ' ~ EXTONOFF_NOT_INSTALLED_EXTS }} )</strong>
 	<form id="extonoff_button_enable" method="post">
-		<input class="button1" type="submit" name="extonoff_enable_all" value="{{ lang('EXTONOFF_ALL_ENABLE') }}">
+		<input class="button1" type="submit" name="extonoff_enable_all" value="{{ lang('EXTONOFF_ALL_ENABLE') }}"{{ EXTONOFF_INACTIVE_EXTS == 0 ? ' disabled' }}>
 	</form>
 {% endif %}

--- a/chris1278/extonoff/adm/style/event/acp_ext_list_enabled_title_after.html
+++ b/chris1278/extonoff/adm/style/event/acp_ext_list_enabled_title_after.html
@@ -1,7 +1,7 @@
 {% if EXTONOFF_INTEGRATION %}
-	{% INCLUDECSS 'css/acp_extonoff_buttons.css' %}
+	{% INCLUDECSS 'css/acp_extonoff_extmgr.css' %}
 	<strong>( {{ EXTONOFF_ACTIVE_EXTS }} )</strong>
 	<form id="extonoff_button_disable" method="post">
-		<input class="button1" type="submit" name="extonoff_disable_all" value="{{ lang('EXTONOFF_ALL_DISABLE') }}">
+		<input class="button1" type="submit" name="extonoff_disable_all" value="{{ lang('EXTONOFF_ALL_DISABLE') }}"{{ EXTONOFF_ACTIVE_EXTS == 1 ? ' disabled' }}>
 	</form>
 {% endif %}

--- a/chris1278/extonoff/composer.json
+++ b/chris1278/extonoff/composer.json
@@ -3,7 +3,7 @@
 	"type": "phpbb-extension",
 	"description": "With this extension it is possible to deactivate or activate all active extensions at once.",
 	"homepage": "https://www.phpbb.de/community/viewtopic.php?f=149&t=242009",
-	"version": "1.0.1-b7",
+	"version": "1.0.1-b8",
 	"time": "2022-04-23",
 	"license": "GPL-2.0-only",
 	"authors": [

--- a/chris1278/extonoff/language/de/acp_extonoff.php
+++ b/chris1278/extonoff/language/de/acp_extonoff.php
@@ -51,9 +51,6 @@ $lang = array_merge($lang, [
 	'EXTONOFF_ACTIVATE_EXPLAIN'				=> 'Durch drücken des Buttons „Alle Erweiterungen aktivieren“ werden alle installierten aber deaktivierten Erweiterungen aktiviert.',
 	'EXTONOFF_ALL_ENABLE'					=> 'Alle Erweiterungen aktivieren',
 
-	// settings info
-	'EXTONOFF_DEACTIVATION_INFO'			=> 'Es können von insgesamt <strong>%2$u</strong> aktiven Erweiterungen <strong>%1$u</strong> Erweiterungen mittels dieser Erweiterung deaktiviert werden.',
-
 	// settings
 	'EXTONOFF_SETTINGS_TITLE'				=> 'Einstellungen',
 	'EXTONOFF_INTEGRATION'					=> 'Integration in „Erweiterungen verwalten“',
@@ -67,14 +64,17 @@ $lang = array_merge($lang, [
 	'EXTONOFF_DEFAULT'						=> 'Standard',
 	'EXTONOFF_INSTALLED'					=> 'installiert',
 	'EXTONOFF_NOT_INSTALLED'				=> 'nicht installiert',
+	'EXTONOFF_EXTENSION_PLURAL'				=> [
+		0 => "0 Erweiterungen",
+		1 => "%u Erweiterung",
+		2 => "%u Erweiterungen",
+	],
 
 	// messages
 	'EXTONOFF_MSG_ACTIVATION_ABORTED'		=> 'Der Vorgang „Alle Erweiterungen aktivieren“ wurde unterbrochen, da die folgende Erweiterung nicht aktiviert werden konnte:',
 	'EXTONOFF_MSG_SETTINGS_SAVED'			=> 'Einstellungen erfolgreich gespeichert.',
-	'EXTONOFF_MSG_CONFIRM_DISABLE'			=> 'Bist du dir sicher, dass du %1$u Erweiterungen deaktivieren möchtest?',
-	'EXTONOFF_MSG_CONFIRM_ENABLE'			=> 'Bist du dir sicher, dass du %1$u Erweiterungen aktivieren möchtest?',
+	'EXTONOFF_MSG_CONFIRM_DISABLE'			=> 'Bist du dir sicher, dass du %s deaktivieren möchtest?',
+	'EXTONOFF_MSG_CONFIRM_ENABLE'			=> 'Bist du dir sicher, dass du %s aktivieren möchtest?',
 	'EXTONOFF_MSG_DEACTIVATION_SUCCESFULL'	=> '%1$u von %2$u aktivierten Erweiterungen wurden deaktiviert.',
-	'EXTONOFF_MSG_DEACTIVATION_UNNECESSARY'	=> 'Die Erweiterungen sind bereits alle deaktiviert. Eine nochmalige Deaktivierung ist nicht notwendig.',
 	'EXTONOFF_MSG_ACTIVATION_SUCCESFULL'	=> '%1$u von %2$u deaktivierten Erweiterungen wurden aktiviert.',
-	'EXTONOFF_MSG_ACTIVATION_UNNECESSARY'	=> 'Die Erweiterungen sind bereits alle aktiviert. Eine nochmalige Aktivierung ist nicht notwendig.',
 ]);

--- a/chris1278/extonoff/language/de_x_sie/acp_extonoff.php
+++ b/chris1278/extonoff/language/de_x_sie/acp_extonoff.php
@@ -51,9 +51,6 @@ $lang = array_merge($lang, [
 	'EXTONOFF_ACTIVATE_EXPLAIN'				=> 'Durch drücken des Buttons „Alle Erweiterungen aktivieren“ werden alle installierten aber deaktivierten Erweiterungen aktiviert.',
 	'EXTONOFF_ALL_ENABLE'					=> 'Alle Erweiterungen aktivieren',
 
-	// settings info
-	'EXTONOFF_DEACTIVATION_INFO'			=> 'Es können von insgesamt <strong>%2$u</strong> aktiven Erweiterungen <strong>%1$u</strong> Erweiterungen mittels dieser Erweiterung deaktiviert werden.',
-
 	// settings
 	'EXTONOFF_SETTINGS_TITLE'				=> 'Einstellungen',
 	'EXTONOFF_INTEGRATION'					=> 'Integration in „Erweiterungen verwalten“',
@@ -67,14 +64,17 @@ $lang = array_merge($lang, [
 	'EXTONOFF_DEFAULT'						=> 'Standard',
 	'EXTONOFF_INSTALLED'					=> 'installiert',
 	'EXTONOFF_NOT_INSTALLED'				=> 'nicht installiert',
+	'EXTONOFF_EXTENSION_PLURAL'				=> [
+		0 => "0 Erweiterungen",
+		1 => "%u Erweiterung",
+		2 => "%u Erweiterungen",
+	],
 
 	// messages
 	'EXTONOFF_MSG_ACTIVATION_ABORTED'		=> 'Der Vorgang „Alle Erweiterungen aktivieren“ wurde unterbrochen, da die folgende Erweiterung nicht aktiviert werden konnte:',
 	'EXTONOFF_MSG_SETTINGS_SAVED'			=> 'Einstellungen erfolgreich gespeichert.',
-	'EXTONOFF_MSG_CONFIRM_DISABLE'			=> 'Sind Sie sich sicher, dass Sie %1$u Erweiterungen deaktivieren möchten?',
-	'EXTONOFF_MSG_CONFIRM_ENABLE'			=> 'Sind Sie sich sicher, dass Sie %1$u Erweiterungen aktivieren möchten?',
+	'EXTONOFF_MSG_CONFIRM_DISABLE'			=> 'Sind Sie sich sicher, dass Sie %s deaktivieren möchten?',
+	'EXTONOFF_MSG_CONFIRM_ENABLE'			=> 'Sind Sie sich sicher, dass Sie %s aktivieren möchten?',
 	'EXTONOFF_MSG_DEACTIVATION_SUCCESFULL'	=> '%1$u von %2$u aktivierten Erweiterungen wurden deaktiviert.',
-	'EXTONOFF_MSG_DEACTIVATION_UNNECESSARY'	=> 'Die Erweiterungen sind bereits alle deaktiviert. Eine nochmalige Deaktivierung ist nicht notwendig.',
 	'EXTONOFF_MSG_ACTIVATION_SUCCESFULL'	=> '%1$u von %2$u deaktivierten Erweiterungen wurden aktiviert.',
-	'EXTONOFF_MSG_ACTIVATION_UNNECESSARY'	=> 'Die Erweiterungen sind bereits alle aktiviert. Eine nochmalige Aktivierung ist nicht notwendig.',
 ]);

--- a/chris1278/extonoff/language/en/acp_extonoff.php
+++ b/chris1278/extonoff/language/en/acp_extonoff.php
@@ -51,9 +51,6 @@ $lang = array_merge($lang, [
 	'EXTONOFF_ACTIVATE_EXPLAIN'				=> 'By pressing the "Activate all extensions" button, all installed but deactivated extensions will be activated.',
 	'EXTONOFF_ALL_ENABLE'					=> 'Activate all extensions',
 
-	// settings info
-	'EXTONOFF_DEACTIVATION_INFO'			=> 'Out of a total of <strong>%2$u</strong> active extensions, <strong>%1$u</strong> extensions can be deactivated using this extension.',
-
 	// settings
 	'EXTONOFF_SETTINGS_TITLE'				=> 'Settings',
 	'EXTONOFF_INTEGRATION'					=> 'Activate additional buttons',
@@ -67,14 +64,17 @@ $lang = array_merge($lang, [
 	'EXTONOFF_DEFAULT'						=> 'Default',
 	'EXTONOFF_INSTALLED'					=> 'installed',
 	'EXTONOFF_NOT_INSTALLED'				=> 'not installed',
+	'EXTONOFF_EXTENSION_PLURAL'				=> [
+		0 => "0 extensions",
+		1 => "%u extension",
+		2 => "%u extensions",
+	],
 
 	// messages
 	'EXTONOFF_MSG_ACTIVATION_ABORTED'		=> 'The "Activate all extensions" operation was interrupted because the following extension could not be activated:',
 	'EXTONOFF_MSG_SETTINGS_SAVED'			=> 'Settings saved successfully.',
-	'EXTONOFF_MSG_CONFIRM_DISABLE'			=> 'Are you sure that you wish to disable %u extensions?',
-	'EXTONOFF_MSG_CONFIRM_ENABLE'			=> 'Are you sure that you wish to enable %u extensions?',
+	'EXTONOFF_MSG_CONFIRM_DISABLE'			=> 'Are you sure that you wish to disable %s?',
+	'EXTONOFF_MSG_CONFIRM_ENABLE'			=> 'Are you sure that you wish to enable %s?',
 	'EXTONOFF_MSG_DEACTIVATION_SUCCESFULL'	=> '%1$u of %2$u enabled extensions have been disabled.',
-	'EXTONOFF_MSG_DEACTIVATION_UNNECESSARY'	=> 'The extensions are already disabled. A repeated deactivation is not necessary.',
 	'EXTONOFF_MSG_ACTIVATION_SUCCESFULL'	=> '%1$u of %2$u disabled extensions have been enabled.',
-	'EXTONOFF_MSG_ACTIVATION_UNNECESSARY'	=> 'The extensions are already activated. A renewed activation is not necessary.',
 ]);


### PR DESCRIPTION
* ACP Modul:
  * In den Button Beschriftungen wird jetzt ebenfalls die Anzahl der aktivierten und deaktivierten Exts angezeigt.
  * Wenn eine Aktion nicht möglich ist, wird der entsprechende Button jetzt gesperrt. Dadurch wird eine unnötige Fehlermeldung mit anschliessender Bestätigung vermieden.
  * Die bisherige Infozeile entfernt, da deren Informationen nun direkt bei den Buttons verfügbar ist.
* Sprachdateien:
  * Nicht mehr benötigte Sprachvariablen entfernt.
  * Plural Array ("Erweiterung/Erweiterungen") für die Rückfrage hinzugefügt.
* `acp_extonoff_buttons.css` in `acp_extonoff_extmgr.css` umbenannt.
* Udos CSS Vorschläge bezüglich Confirm Box in das ExtMgr CSS übernommen.
* Code Bereinigung und Optimierung.