### PR TITLE
1.0.1-b13

### DIFF
--- a/chris1278/extonoff/adm/style/acp_extonoff_main.html
+++ b/chris1278/extonoff/adm/style/acp_extonoff_main.html
@@ -90,6 +90,10 @@
 		<input class="button2" type="reset" id="reset" name="reset" value="{{ lang('RESET') }}">
 	</p>
 
+	<p class="extonoff_copyright">
+		{{ EXTONOFF_EXT_NAME }} {{ EXTONOFF_EXT_VER }} &copy; 2022 chris1278 &amp; LukeWCS<br />
+	</p>
+
 {S_FORM_TOKEN}
 </form>
 

--- a/chris1278/extonoff/adm/style/css/acp_extonoff.css
+++ b/chris1278/extonoff/adm/style/css/acp_extonoff.css
@@ -38,6 +38,12 @@ input[type="submit"]:disabled {
 	font-size: .9em;
 }
 
+.extonoff_copyright {
+	margin-top: 1em;
+	text-align: center;
+	font-size: .75em;
+}
+
 /* Ext manager */
 
 #extonoff_button_enable,
@@ -50,7 +56,7 @@ input[type="submit"]:disabled {
 	cursor: help;
 }
 
-.extonoff_migration_icon:before {
+.extonoff_migration_icon:after {
 	font-family: FontAwesome;
 	content: "\f062";
 }

--- a/chris1278/extonoff/adm/style/event/acp_ext_list_disabled_name_after.html
+++ b/chris1278/extonoff/adm/style/event/acp_ext_list_disabled_name_after.html
@@ -1,3 +1,3 @@
-{% if EXTONOFF_INTEGRATION && disabled.NAME in EXTONOFF_MIGRATION_TECHNAMES %}
-	<span class="extonoff_migration_icon" title="{{ lang('EXTONOFF_TOOLTIP_HAS_MIGRATION') }}"></span>
+{% if EXTONOFF_INTEGRATION && disabled.NAME in EXTONOFF_MIGRATION_EXTS|keys %}
+	<span class="extonoff_migration_icon" title="{{ lang('EXTONOFF_TOOLTIP_HAS_MIGRATION') }}">({{ EXTONOFF_MIGRATION_EXTS[disabled.NAME] }}) </span>
 {% endif %}

--- a/chris1278/extonoff/adm/style/event/acp_ext_list_disabled_title_after.html
+++ b/chris1278/extonoff/adm/style/event/acp_ext_list_disabled_title_after.html
@@ -2,8 +2,8 @@
 	{% INCLUDECSS 'css/acp_extonoff.css' %}
 	<strong>( {{ 
 		lang('EXTONOFF_INSTALLED') ~ lang('COLON') ~ ' ' ~ EXTONOFF_COUNT_INACTIVE ~ ' / ' ~ 
-		lang('EXTONOFF_NOT_INSTALLED') ~ lang('COLON') ~ ' ' ~ EXTONOFF_COUNT_NOT_INSTALLED ~ ' / ' ~ 
-		lang('EXTONOFF_HAS_MIGRATION') ~ lang('COLON') ~ ' ' ~ EXTONOFF_COUNT_HAS_MIGRATION
+		lang('EXTONOFF_HAS_MIGRATION') ~ lang('COLON') ~ ' ' ~ EXTONOFF_COUNT_HAS_MIGRATION ~ ' / ' ~ 
+		lang('EXTONOFF_NOT_INSTALLED') ~ lang('COLON') ~ ' ' ~ EXTONOFF_COUNT_NOT_INSTALLED
 	}} )</strong>
 	<form id="extonoff_button_enable" method="post" action="{{ U_ACTION }}">
 		<input class="button1" type="submit" name="extonoff_enable_all" value="{{ lang('EXTONOFF_ALL_ENABLE') }}"{{ (EXTONOFF_COUNT_INACTIVE - EXTONOFF_COUNT_HAS_MIGRATION == 0) ? ' disabled' }}>

--- a/chris1278/extonoff/composer.json
+++ b/chris1278/extonoff/composer.json
@@ -3,7 +3,7 @@
 	"type": "phpbb-extension",
 	"description": "With this extension it is possible to deactivate or activate all active extensions at once.",
 	"homepage": "https://www.phpbb.de/community/viewtopic.php?f=149&t=242009",
-	"version": "1.0.1-b12",
+	"version": "1.0.1-b13",
 	"time": "2022-04-23",
 	"license": "GPL-2.0-only",
 	"authors": [

--- a/chris1278/extonoff/language/de/acp_extonoff.php
+++ b/chris1278/extonoff/language/de/acp_extonoff.php
@@ -61,7 +61,7 @@ $lang = array_merge($lang, [
 	// settings expert
 	'EXTONOFF_EXPERT_SETTINGS_TITLE'		=> 'Experten-Einstellungen',
 	'EXTONOFF_MIGRATIONS'					=> 'Erlaube Migrationen',
-	'EXTONOFF_MIGRATIONS_EXPLAIN'			=> 'Wenn du diese Option aktivierst, dann können bei der Aktion „Alle aktivieren“ auch diejenigen Erweiterungen aktiviert werden, bei denen neue Migrationsdateien vorliegen, die noch nicht installiert wurden. Das trifft auf aktualisierte Erweiterungen zu, die einen Ordner „migrations“ enthalten. Ohne diese Option müssen solche Erweiterungen manuell aktiviert werden, was empfohlen wird.',
+	'EXTONOFF_MIGRATIONS_EXPLAIN'			=> 'Wenn du diese Option aktivierst, dann können bei der Aktion „Alle aktivieren“ auch diejenigen Erweiterungen aktiviert werden, bei denen neue Migrationsdateien vorliegen. Das trifft auf aktualisierte Erweiterungen zu, die einen Ordner „migrations“ enthalten. Ohne diese Option müssen solche Erweiterungen manuell aktiviert werden, was empfohlen wird.',
 
 	// ext manager
 	'EXTONOFF_ALL_DISABLE'					=> 'Alle deaktivieren',

--- a/chris1278/extonoff/language/de_x_sie/acp_extonoff.php
+++ b/chris1278/extonoff/language/de_x_sie/acp_extonoff.php
@@ -61,7 +61,7 @@ $lang = array_merge($lang, [
 	// settings expert
 	'EXTONOFF_EXPERT_SETTINGS_TITLE'		=> 'Experten-Einstellungen',
 	'EXTONOFF_MIGRATIONS'					=> 'Erlaube Migrationen',
-	'EXTONOFF_MIGRATIONS_EXPLAIN'			=> 'Wenn Sie diese Option aktivieren, dann können bei der Aktion „Alle aktivieren“ auch diejenigen Erweiterungen aktiviert werden, bei denen neue Migrationsdateien vorliegen, die noch nicht installiert wurden. Das trifft auf aktualisierte Erweiterungen zu, die einen Ordner „migrations“ enthalten. Ohne diese Option müssen solche Erweiterungen manuell aktiviert werden, was empfohlen wird.',
+	'EXTONOFF_MIGRATIONS_EXPLAIN'			=> 'Wenn Sie diese Option aktivieren, dann können bei der Aktion „Alle aktivieren“ auch diejenigen Erweiterungen aktiviert werden, bei denen neue Migrationsdateien vorliegen. Das trifft auf aktualisierte Erweiterungen zu, die einen Ordner „migrations“ enthalten. Ohne diese Option müssen solche Erweiterungen manuell aktiviert werden, was empfohlen wird.',
 
 	// ext manager
 	'EXTONOFF_ALL_DISABLE'					=> 'Alle deaktivieren',

--- a/chris1278/extonoff/language/en/acp_extonoff.php
+++ b/chris1278/extonoff/language/en/acp_extonoff.php
@@ -61,7 +61,7 @@ $lang = array_merge($lang, [
 	// settings expert
 	'EXTONOFF_EXPERT_SETTINGS_TITLE'		=> 'Expert settings',
 	'EXTONOFF_MIGRATIONS'					=> 'Allow migrations',
-	'EXTONOFF_MIGRATIONS_EXPLAIN'			=> 'If you activate this option, the "Enable all" action can also activate those extensions that have new migration files that have not yet been installed. This applies to updated extensions that contain a "migrations" folder. Without this option, such extensions must be activated manually, which is recommended.',
+	'EXTONOFF_MIGRATIONS_EXPLAIN'			=> 'If you activate this option, the "Enable all" action can also activate those extensions that have new migration files. This applies to updated extensions that contain a "migrations" folder. Without this option, such extensions must be activated manually, which is recommended.',
 
 	// ext manager
 	'EXTONOFF_ALL_DISABLE'					=> 'Disable all',


### PR DESCRIPTION
* Fix: Die Funktion zur Erkennung neuer Migrationsdateien greift per Standard auf eine Liste im Cache zurück, wodurch je nach Situation ein veralteter Zustand ermittelt wird. Dadurch werden neue Migrationen dann nicht erkannt und somit nicht angezeigt.
* ExtMgr Template "Deaktivieren":
  * Reihenfolge der Infos auf "installiert / neue Migrationen / nicht installiert" geändert, da nicht installierte Exts für ExtOnOff keine Relevanz haben.
* ExtMgr Template "Migration-Hinweis":
  * Es wird jetzt zusätzlich die Anzahl der neuen Migrationsdateien angezeigt.
* Controller:
  * Hilfsfunktionen im Code kommentiert.
* Modul Template:
  * Footer eingebaut, der Ext Name und Version von ExtOnOff anzeigt. Übernommen von LFWWH.
* Code Optimierung.