### PR TITLE
2.0.0-b16

### DIFF
--- a/chris1278/extonoff/adm/style/acp_extonoff_main.html
+++ b/chris1278/extonoff/adm/style/acp_extonoff_main.html
@@ -7,7 +7,7 @@
 
 {% if EXTONOFF_NOTES %}
 <div class="errorbox notice">
-	{{ EXTONOFF_NOTES }}
+	{{ EXTONOFF_NOTES|e('html') }}
 </div>
 {% endif %}
 
@@ -21,7 +21,7 @@
 				<span>{{ lang('EXTONOFF_DEACTIVATE_EXPLAIN') }}</span>
 			</dt>
 			<dd>
-				<label><input class="button1" type="submit" name="extonoff_disable_all" value="{{ lang('EXTONOFF_ALL_DISABLE') }} ({{ EXTONOFF_COUNT_ACTIVE }})"{{ EXTONOFF_COUNT_ACTIVE == 0 ? ' disabled' }}></label>
+				<label><input class="button1" type="submit" name="extonoff_disable_all" value="{{ lang('EXTONOFF_ALL_DISABLE') }} ({{ EXTONOFF_COUNT_ENABLED_CLEAN }})"{{ EXTONOFF_COUNT_ENABLED_CLEAN == 0 ? ' disabled' }}></label>
 			</dd>
 		</dl>
 		<dl>
@@ -30,7 +30,7 @@
 				<span>{{ lang('EXTONOFF_ACTIVATE_EXPLAIN') }}</span>
 			</dt>
 			<dd>
-				<label><input class="button1" type="submit" name="extonoff_enable_all" value="{{ lang('EXTONOFF_ALL_ENABLE') }} ({{ EXTONOFF_COUNT_INACTIVE }})"{{ EXTONOFF_COUNT_INACTIVE == 0 ? ' disabled' }}></label>
+				<label><input class="button1" type="submit" name="extonoff_enable_all" value="{{ lang('EXTONOFF_ALL_ENABLE') }} ({{ EXTONOFF_COUNT_DISABLED_CLEAN }})"{{ EXTONOFF_COUNT_DISABLED_CLEAN == 0 ? ' disabled' }}></label>
 			</dd>
 		</dl>
 	</fieldset>

--- a/chris1278/extonoff/adm/style/event/acp_ext_list_disabled_name_after.html
+++ b/chris1278/extonoff/adm/style/event/acp_ext_list_disabled_name_after.html
@@ -1,3 +1,3 @@
 {% if EXTONOFF_INTEGRATION && disabled.NAME in EXTONOFF_MIGRATION_EXTS|keys %}
-	<span class="extonoff_migration_icon" title="{{ lang('EXTONOFF_TOOLTIP_HAS_MIGRATION') }}">({{ EXTONOFF_MIGRATION_EXTS[disabled.NAME] }}) </span>
+	<span class="extonoff_migration_icon" title="{{ lang('EXTONOFF_TOOLTIP_HAS_MIGRATION')|e('html') }}">({{ EXTONOFF_MIGRATION_EXTS[disabled.NAME] }}) </span>
 {% endif %}

--- a/chris1278/extonoff/adm/style/event/acp_ext_list_disabled_title_after.html
+++ b/chris1278/extonoff/adm/style/event/acp_ext_list_disabled_title_after.html
@@ -1,11 +1,13 @@
 {% if EXTONOFF_INTEGRATION %}
-	{% INCLUDECSS 'css/acp_extonoff.css' %}
-	<strong>( {{ 
-		lang('EXTONOFF_INSTALLED') ~ lang('COLON') ~ ' ' ~ EXTONOFF_COUNT_INACTIVE ~ ' / ' ~ 
-		lang('EXTONOFF_HAS_MIGRATION') ~ lang('COLON') ~ ' ' ~ EXTONOFF_COUNT_HAS_MIGRATION ~ ' / ' ~ 
-		lang('EXTONOFF_NOT_INSTALLED') ~ lang('COLON') ~ ' ' ~ EXTONOFF_COUNT_NOT_INSTALLED
-	}} )</strong>
+{% spaceless %}
+	<strong>{{ 
+		lang('COLON') ~ ' ' ~ EXTONOFF_COUNT_INACTIVE  ~ ' (' ~
+		lang('EXTONOFF_INSTALLED') ~ lang('COLON') ~ ' ' ~ EXTONOFF_COUNT_DISABLED ~ ' / ' ~
+		lang('EXTONOFF_HAS_MIGRATION') ~ lang('COLON') ~ ' ' ~ EXTONOFF_COUNT_HAS_MIGRATION ~ ' / ' ~
+		lang('EXTONOFF_NOT_INSTALLED') ~ lang('COLON') ~ ' ' ~ EXTONOFF_COUNT_NOT_INSTALLED ~ ')'
+	}}</strong>
+{% endspaceless %}
 	<form id="extonoff_button_enable" method="post" action="{{ U_ACTION }}">
-		<input class="button1" type="submit" name="extonoff_enable_all" value="{{ lang('EXTONOFF_ALL_ENABLE') }}"{{ (EXTONOFF_COUNT_INACTIVE - EXTONOFF_COUNT_HAS_MIGRATION == 0) ? ' disabled' }}>
+		<input class="button1" type="submit" name="extonoff_enable_all" value="{{ lang('EXTONOFF_ALL_ENABLE') }}" title="{{ EXTONOFF_TOOLTIP_BUTTON_ENABLE|e('html') }}"{{ (EXTONOFF_COUNT_DISABLED_CLEAN == 0) ? ' disabled' }}>
 	</form>
 {% endif %}

--- a/chris1278/extonoff/adm/style/event/acp_ext_list_enabled_title_after.html
+++ b/chris1278/extonoff/adm/style/event/acp_ext_list_enabled_title_after.html
@@ -1,7 +1,11 @@
 {% if EXTONOFF_INTEGRATION %}
+{% spaceless %}
+	<strong>{{ 
+		lang('COLON') ~ ' ' ~ EXTONOFF_COUNT_ENABLED
+	}}</strong>
+{% endspaceless %}
 	{% INCLUDECSS 'css/acp_extonoff.css' %}
-	<strong>( {{ EXTONOFF_COUNT_ACTIVE }} )</strong>
 	<form id="extonoff_button_disable" method="post" action="{{ U_ACTION }}">
-		<input class="button1" type="submit" name="extonoff_disable_all" value="{{ lang('EXTONOFF_ALL_DISABLE') }}"{{ (EXTONOFF_COUNT_ACTIVE == 1) ? ' disabled' }}>
+		<input class="button1" type="submit" name="extonoff_disable_all" value="{{ lang('EXTONOFF_ALL_DISABLE') }}" title="{{ EXTONOFF_TOOLTIP_BUTTON_DISABLE|e('html') }}"{{ (EXTONOFF_COUNT_ENABLED_CLEAN == 0) ? ' disabled' }}>
 	</form>
 {% endif %}

--- a/chris1278/extonoff/composer.json
+++ b/chris1278/extonoff/composer.json
@@ -3,7 +3,7 @@
 	"type": "phpbb-extension",
 	"description": "With this extension it is possible to deactivate or activate all active extensions at once.",
 	"homepage": "https://www.phpbb.de/community/viewtopic.php?f=149&t=242009",
-	"version": "1.1.0-b15",
+	"version": "2.0.0-b16",
 	"time": "2022-04-23",
 	"license": "GPL-2.0-only",
 	"authors": [

--- a/chris1278/extonoff/language/de/acp_extonoff.php
+++ b/chris1278/extonoff/language/de/acp_extonoff.php
@@ -84,7 +84,9 @@ $lang = array_merge($lang, [
 	],
 
 	// tooltips
-	'EXTONOFF_TOOLTIP_HAS_MIGRATION'		=> 'Diese Erweiterung hat neue Migrationen, die beim aktivieren der Erweiterung übernommen werden.',
+	'EXTONOFF_TOOLTIP_HAS_MIGRATION'		=> 'Diese Erweiterung hat neue Migrationsdateien, die beim aktivieren der Erweiterung übernommen werden.',
+	'EXTONOFF_TOOLTIP_BUTTON_DISABLE'		=> '%s deaktivieren.',
+	'EXTONOFF_TOOLTIP_BUTTON_ENABLE'		=> '%s aktivieren.',
 
 	// messages
 	'EXTONOFF_MSG_SETTINGS_SAVED'			=> 'ExtOnOff: Einstellungen erfolgreich gespeichert.',

--- a/chris1278/extonoff/language/de_x_sie/acp_extonoff.php
+++ b/chris1278/extonoff/language/de_x_sie/acp_extonoff.php
@@ -84,7 +84,9 @@ $lang = array_merge($lang, [
 	],
 
 	// tooltips
-	'EXTONOFF_TOOLTIP_HAS_MIGRATION'		=> 'Diese Erweiterung hat neue Migrationen, die beim aktivieren der Erweiterung übernommen werden.',
+	'EXTONOFF_TOOLTIP_HAS_MIGRATION'		=> 'Diese Erweiterung hat neue Migrationsdateien, die beim aktivieren der Erweiterung übernommen werden.',
+	'EXTONOFF_TOOLTIP_BUTTON_DISABLE'		=> '%s deaktivieren.',
+	'EXTONOFF_TOOLTIP_BUTTON_ENABLE'		=> '%s aktivieren.',
 
 	// messages
 	'EXTONOFF_MSG_SETTINGS_SAVED'			=> 'ExtOnOff: Einstellungen erfolgreich gespeichert.',

--- a/chris1278/extonoff/language/en/acp_extonoff.php
+++ b/chris1278/extonoff/language/en/acp_extonoff.php
@@ -84,7 +84,9 @@ $lang = array_merge($lang, [
 	],
 
 	// tooltips
-	'EXTONOFF_TOOLTIP_HAS_MIGRATION'		=> 'This extension has new migrations that are applied upon activation of the extension.',
+	'EXTONOFF_TOOLTIP_HAS_MIGRATION'		=> 'This extension has new migration files that are applied when activating the extension.',
+	'EXTONOFF_TOOLTIP_BUTTON_DISABLE'		=> 'Disable %s.',
+	'EXTONOFF_TOOLTIP_BUTTON_ENABLE'		=> 'Enable %s.',
 
 	// messages
 	'EXTONOFF_MSG_SETTINGS_SAVED'			=> 'ExtOnOff: Settings saved successfully.',

--- a/chris1278/extonoff/migrations/v_2_0_0_acp_module.php
+++ b/chris1278/extonoff/migrations/v_2_0_0_acp_module.php
@@ -10,7 +10,7 @@
 
 namespace chris1278\extonoff\migrations;
 
-class v_1_1_0_acp_module extends \phpbb\db\migration\migration
+class v_2_0_0_acp_module extends \phpbb\db\migration\migration
 {
 	public static function depends_on()
 	{

--- a/chris1278/extonoff/migrations/v_2_0_0_database.php
+++ b/chris1278/extonoff/migrations/v_2_0_0_database.php
@@ -10,11 +10,11 @@
 
 namespace chris1278\extonoff\migrations;
 
-class v_1_1_0_database extends \phpbb\db\migration\migration
+class v_2_0_0_database extends \phpbb\db\migration\migration
 {
 	public static function depends_on()
 	{
-		return ['\chris1278\extonoff\migrations\v_1_1_0_acp_module'];
+		return ['\chris1278\extonoff\migrations\v_2_0_0_acp_module'];
 	}
 
 	public function update_data()

--- a/extonoff_changelog.md
+++ b/extonoff_changelog.md
@@ -1,12 +1,13 @@
-#### 1.1.0
+#### 2.0.0
 
-Danke an Kirk und 69bruno die uns beim testen geholfen haben. :)
+Danke an Kirk und 69bruno die uns beim testen geholfen haben. :-)
 
-Hinweis: Diese Version ist nicht kompatibel mit 1.0.0. Bevor 1.1.0 installiert werden kann, muss 1.0.0 deinstalliert werden (Arbeitsdaten löschen).
+Hinweis: Diese Version ist nicht kompatibel mit 1.0.0. Bevor 2.0.0 installiert werden kann, muss 1.0.0 deinstalliert werden. Dazu im ACP in der Ansicht "ANPASSEN" die Kurzanleitung "EINE ERWEITERUNG KOMPLETT AUS DEM BOARD ENTFERNEN" am Ende der Seite berücksichtigen.
 
 * Fix: Nach der Reaktivierung funktionierten manche Erweiterungen nicht korrekt, was primär auf deren Template Darstellungen bezogen ist. Die Ursache für das Problem war der Twig Cache, der nicht mehr vollständig aufgebaut wurde. Ein Workaround sorgt nun dafür, dass der gesamte Cache nach Aktivierung/Deaktivierung wieder vollständig aufgebaut wird.
 * Fix: Mehrere kleinere Fehler behoben. Unter anderem fehlte im ACP Modul das Security Token, dass in jedem Formular vorhanden sein muss.
 * Wenn eine Erweiterung aufgrund fehlender Voraussetzungen nicht aktiviert werden kann und eine eigene Fehlerbehandlung hat (`trigger_error`), dann unterbricht diese Erweiterung den kompletten Aktivierungsvorgang. Dafür eine zusätzliche Anzeige eingebaut die dann in der Standard Fehlermeldung von phpBB präzise Auskunft darüber gibt, welche Erweiterung den Vorgang unterbrochen hat.
+* Wenn die Aktion "Alle aktivieren" durch eine Erweiterung hart unterbrochen wird, dann kann jetzt trotzdem ein Log Eintrag erzeugt werden, der den partiellen Erfolg protokolliert.
 * Deaktivierte Erweiterungen werden nun auf neue Migrationsdateien geprüft. Sind solche vorhanden, werden die betreffenden Erweiterungen bei der Aktivierung per Standard ignoriert.
 * In der Bestätigungsmeldung die phpBB nach Aktivierung/Deaktivierung angezeigt, wird die Anzahl der erfolgreich geschalteten Erweiterungen und die Gesamtzahl angezeigt. Dadurch ist sofort erkennbar, ob bei einer Aktion eine Erweiterung nicht geschaltet werden konnte.
 * Im Log wird nun ebenfalls die Anzahl der erfolgreich geschalteten Erweiterungen und die Gesamtzahl protokolliert.


### PR DESCRIPTION
* Fix: Wenn alle deaktivierten Exts neue Migrationen hatten und der Migrator Schalter auf Ja gesetzt wurde, blieb der Button zum Aktivieren im ExtMgr weiterhin deaktiviert.
* Fix: Im ExtMgr wurde das ExtOnOff CSS unnötig doppelt geladen.
* ExtMgr Template "Aktivieren":
  * Button hat jetzt Tooltip der anzeigt, wie viele Exts geschaltet werden.
  * Twig Code angepasst.
* ExtMgr Template "Deaktivieren":
  * Bei "Deaktivierte Erweiterungen" wird jetzt auch die Gesamtzahl der deaktivierten Exts angezeigt, wie bei "Aktivierte Erweiterungen".
  * Button hat jetzt Tooltip der anzeigt, wie viele Exts geschaltet werden.
  * Twig Code angepasst.
* ExtMgr Template "Migration-Hinweis":
  * Beim Tooltip des Migrator Symbols (Pfeil) wird jetzt per Twig Filter auf Sonderzeichen geprüft und konvertiert.
* Modul Template:
  * Twig Code angepasst.
* Controller:
  * Template Variablen umbenannt.
  * Neue Template Variablen hinzugefügt.
  * Code Optimierung.
* Neue Sprachvariablen für die Button Tooltips.
* Composer auf 2.0.0 umgestellt.
* Offizielles Changelog aktualisiert.